### PR TITLE
Add support for model-specific prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,18 @@ You have complete control over your Hash Id length and style. Check out the conf
 
 ## Table of contents
 
+- [Table of contents](#table-of-contents)
 - [Features](#features)
 - [Compatibility Table](#compatibility-table)
 - [Installation](#installation)
 - [Usage](#usage)
-    - [Model Hash Id Generation](#model-hash-id-generation)
-    - [Routing and Route Model Binding (Optional)](#routing-and-route-model-binding-optional)
-    - [Saving Hash Ids to the Database (Optional)](#saving-hash-ids-to-the-database-optional)
+  - [Model Hash Id Generation](#model-hash-id-generation)
+    - [Model Attributes and Static Model Functions](#model-attributes-and-static-model-functions)
+    - [Query Builder Functions](#query-builder-functions)
+  - [Routing and Route Model Binding (Optional)](#routing-and-route-model-binding-optional)
+    - [Route Model Binding (Implicit)](#route-model-binding-implicit)
+    - [Route Model Binding (Explicit)](#route-model-binding-explicit)
+  - [Saving Hash Ids to the Database (Optional)](#saving-hash-ids-to-the-database-optional)
 - [Hash Id Terminology](#hash-id-terminology)
 - [Configuration](#configuration)
 - [Roadmap](#roadmap)
@@ -69,6 +74,7 @@ You have complete control over your Hash Id length and style. Check out the conf
   - Model Prefix Length and Case
   - Separator
 - Model Specific Hash Id Generation
+  - Optional, user-defined prefix per Model
   - Define separate configurations per Model
 - Route (Model) Binding using Hash Ids (optional)
 - Automatically save Hash Ids to the database (optional)
@@ -78,12 +84,12 @@ You have complete control over your Hash Id length and style. Check out the conf
 The table below shows the compatibility across Laravel, PHP, and this package's **current version**.
 
 | Package Version | Laravel version | PHP version | Compatible |
-|-----------------|-----------------|-------------|------------|
-| ^2.0            | 9.*             | 8.1.*       |      ✅    |
-| ^1.0            | 8.*             | 8.0.*       |      ✅    |
-|                 | 8.*             | 7.4.*       |      ❌    |
-|                 | 8.*             | 7.3.*       |      ❌    |
-|                 | 7.x             | *           |      ❌    |
+| --------------- | --------------- | ----------- | ---------- |
+| ^2.0            | 9.*             | 8.1.*       | ✅          |
+| ^1.0            | 8.*             | 8.0.*       | ✅          |
+|                 | 8.*             | 7.4.*       | ❌          |
+|                 | 8.*             | 7.3.*       | ❌          |
+|                 | 7.x             | *           | ❌          |
 
 ## Installation
 
@@ -354,9 +360,18 @@ return [
         // App\Models\User::class => [
         //     'salt'            => 'your-model-specific-salt-string',
         //     'length'          => 13,
-        //     'alphabet'        => 'abcdefghjklmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ234567890',
+        //     'alphabet'        => 'abcdefghjklmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ234567890', 
         //     'prefix_length'   => 3,
         //     'prefix_case'     => 'lower',
+        //     'separator'       => '_',
+        //     'database_column' => 'hash_id',
+        // ],
+
+        // App\Models\Post::class => [
+        //     'salt'            => 'your-model-specific-salt-string',
+        //     'length'          => 13,
+        //     'alphabet'        => 'abcdefghjklmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ234567890',
+        //     'prefix'          => 'abc', // prefix will be 'abc', not a generated prefix
         //     'separator'       => '_',
         //     'database_column' => 'hash_id',
         // ],
@@ -365,7 +380,7 @@ return [
 ```
 
 ## Roadmap
-- [ ] Custom Model Prefixes (Not generated from a Model name)
+- [x] Custom Model Prefixes (Not generated from a Model name)
 - [ ] Hash Id Validation  Rules
 - [ ] Generic Generators (Not bound to a Laravel Model)
 

--- a/README.md
+++ b/README.md
@@ -42,18 +42,13 @@ You have complete control over your Hash Id length and style. Check out the conf
 
 ## Table of contents
 
-- [Table of contents](#table-of-contents)
 - [Features](#features)
 - [Compatibility Table](#compatibility-table)
 - [Installation](#installation)
 - [Usage](#usage)
-  - [Model Hash Id Generation](#model-hash-id-generation)
-    - [Model Attributes and Static Model Functions](#model-attributes-and-static-model-functions)
-    - [Query Builder Functions](#query-builder-functions)
-  - [Routing and Route Model Binding (Optional)](#routing-and-route-model-binding-optional)
-    - [Route Model Binding (Implicit)](#route-model-binding-implicit)
-    - [Route Model Binding (Explicit)](#route-model-binding-explicit)
-  - [Saving Hash Ids to the Database (Optional)](#saving-hash-ids-to-the-database-optional)
+    - [Model Hash Id Generation](#model-hash-id-generation)
+    - [Routing and Route Model Binding (Optional)](#routing-and-route-model-binding-optional)
+    - [Saving Hash Ids to the Database (Optional)](#saving-hash-ids-to-the-database-optional)
 - [Hash Id Terminology](#hash-id-terminology)
 - [Configuration](#configuration)
 - [Roadmap](#roadmap)
@@ -84,12 +79,12 @@ You have complete control over your Hash Id length and style. Check out the conf
 The table below shows the compatibility across Laravel, PHP, and this package's **current version**.
 
 | Package Version | Laravel version | PHP version | Compatible |
-| --------------- | --------------- | ----------- | ---------- |
-| ^2.0            | 9.*             | 8.1.*       | ✅          |
-| ^1.0            | 8.*             | 8.0.*       | ✅          |
-|                 | 8.*             | 7.4.*       | ❌          |
-|                 | 8.*             | 7.3.*       | ❌          |
-|                 | 7.x             | *           | ❌          |
+|-----------------|-----------------|-------------|------------|
+| ^2.0            | 9.*             | 8.1.*       |      ✅    |
+| ^1.0            | 8.*             | 8.0.*       |      ✅    |
+|                 | 8.*             | 7.4.*       |      ❌    |
+|                 | 8.*             | 7.3.*       |      ❌    |
+|                 | 7.x             | *           |      ❌    |
 
 ## Installation
 
@@ -360,7 +355,7 @@ return [
         // App\Models\User::class => [
         //     'salt'            => 'your-model-specific-salt-string',
         //     'length'          => 13,
-        //     'alphabet'        => 'abcdefghjklmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ234567890', 
+        //     'alphabet'        => 'abcdefghjklmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ234567890',
         //     'prefix_length'   => 3,
         //     'prefix_case'     => 'lower',
         //     'separator'       => '_',
@@ -370,10 +365,9 @@ return [
         // App\Models\Post::class => [
         //     'salt'            => 'your-model-specific-salt-string',
         //     'length'          => 13,
-        //     'alphabet'        => 'abcdefghjklmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ234567890',
-        //     'prefix'          => 'abc', // prefix will be 'abc', not a generated prefix
+        //     'alphabet'        => 'abcdefghjklmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ234567890', 
+        //     'prefix'          => 'abc', // Custom prefix that is not auto-generated
         //     'separator'       => '_',
-        //     'database_column' => 'hash_id',
         // ],
     ],
 ];

--- a/config/model-hashid.php
+++ b/config/model-hashid.php
@@ -127,5 +127,14 @@ return [
         //     'separator'       => '_',
         //     'database_column' => 'hash_id',
         // ],
+
+        // App\Models\Post::class => [
+        //     'salt'            => 'your-model-specific-salt-string',
+        //     'length'          => 13,
+        //     'alphabet'        => 'abcdefghjklmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ234567890',
+        //     'prefix'          => 'abc', // prefix will be 'abc', not a generated prefix
+        //     'separator'       => '_',
+        //     'database_column' => 'hash_id',
+        // ],
     ],
 ];

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -23,19 +23,34 @@ class Config
 
         if ($model === null) {
             return LaravelConfig::get(ConfigParameters::CONFIG_FILE_NAME.'.'.$parameter);
-        }
+        };
 
-        self::isModelClassExist($model);
-
-        $className = $model instanceof Model ? get_class($model) : $model;
-
-        // Return specific config for model if defined
-        if (Arr::has(LaravelConfig::get(ConfigParameters::CONFIG_FILE_NAME.'.'.ConfigParameters::MODEL_GENERATORS), $className.'.'.$parameter)) {
-            return LaravelConfig::get(ConfigParameters::CONFIG_FILE_NAME.'.'.ConfigParameters::MODEL_GENERATORS)[$className][$parameter];
+        // Return the model specific configuration value if it exists.
+        if (($specificConfig = self::getForModel($parameter, $model)) && !is_null($specificConfig)) {
+            return $specificConfig;
         }
 
         // Return generic config
         return LaravelConfig::get(ConfigParameters::CONFIG_FILE_NAME.'.'.$parameter);
+    }
+
+    /**
+     * Gets a model specific configuration value, returning null if it doesn't exist.
+     *
+     * @throws \Deligoez\LaravelModelHashId\Exceptions\UnknownHashIdConfigParameterException
+     */
+    public static function getForModel(string $parameter, Model | string $model): string | int | array | null
+    {
+        self::isParameterDefined($parameter);
+
+        $className = $model instanceof Model ? get_class($model) : $model;
+
+        // Get the model specific configuration value if it exists.
+        if (Arr::has(LaravelConfig::get(ConfigParameters::CONFIG_FILE_NAME.'.'.ConfigParameters::MODEL_GENERATORS), $className.'.'.$parameter)) {
+            return LaravelConfig::get(ConfigParameters::CONFIG_FILE_NAME.'.'.ConfigParameters::MODEL_GENERATORS)[$className][$parameter];
+        }
+
+        return null;
     }
 
     /**
@@ -63,6 +78,7 @@ class Config
 
         LaravelConfig::set(ConfigParameters::CONFIG_FILE_NAME.'.'.ConfigParameters::MODEL_GENERATORS, $generatorsConfig);
     }
+
 
     /**
      * Check for recognized configuration value.

--- a/src/Support/ConfigParameters.php
+++ b/src/Support/ConfigParameters.php
@@ -27,6 +27,11 @@ class ConfigParameters
     public const ALPHABET = 'alphabet';
 
     /*
+     * Hash Id configuration key name for PREFIX.
+     */
+    public const PREFIX = 'prefix';
+
+    /*
      * Hash Id configuration key name for PREFIX_LENGTH.
      */
     public const PREFIX_LENGTH = 'prefix_length';
@@ -58,6 +63,7 @@ class ConfigParameters
         self::SALT,
         self::LENGTH,
         self::ALPHABET,
+        self::PREFIX,
         self::PREFIX_LENGTH,
         self::PREFIX_CASE,
         self::SEPARATOR,

--- a/src/Support/Generator.php
+++ b/src/Support/Generator.php
@@ -20,6 +20,10 @@ class Generator
     {
         Config::isModelClassExist($model);
 
+        if (($prefix = Config::getForModel(ConfigParameters::PREFIX, $model)) && !is_null($prefix)) {
+            return $prefix;
+        }
+
         $shortClassName = class_basename($model);
         $prefixLength = (int) Config::get(ConfigParameters::PREFIX_LENGTH, $model);
         $prefix = $prefixLength < 0

--- a/tests/Support/ModelHashIdGeneratorTest.php
+++ b/tests/Support/ModelHashIdGeneratorTest.php
@@ -18,6 +18,49 @@ class ModelHashIdGeneratorTest extends TestCase
 {
     use WithFaker;
 
+    // region prefix
+
+    /** @test */
+    public function it_uses_default_prefix_logic_when_override_is_not_defined(): void
+    {
+        // 1️⃣ Arrange 🏗
+        $model = new ModelA();
+        $prefixLength = $this->faker->numberBetween(1, mb_strlen(class_basename($model)));
+        Config::set(ConfigParameters::PREFIX_LENGTH, $prefixLength, $model);
+
+        // 2️⃣ Act 🏋🏻‍
+        $prefix = Generator::buildPrefixForModel($model);
+
+        // 3️⃣ Assert ✅
+        $this->assertEquals($prefixLength, mb_strlen($prefix));
+    }
+
+    /** @test */
+    public function it_can_use_a_defined_prefix_from_a_model_generator(): void
+    {
+        // 1️⃣ Arrange 🏗
+        $modelSeparator = '_';
+        $modelPrefix = 'a_custom_prefix';
+
+        Config::set(ConfigParameters::SEPARATOR, $modelSeparator, ModelA::class);
+        Config::set(ConfigParameters::PREFIX, $modelPrefix, ModelA::class);
+
+        $model = ModelA::factory()->create();
+
+        // 2️⃣ Act 🏋🏻‍
+        $hashId = Generator::forModel($model);
+
+        // 3️⃣ Assert ✅
+        $modelHash = Generator::parseHashIDForModel($hashId);
+
+        $this->assertEquals($modelPrefix, $modelHash->prefix);
+        $this->assertEquals($modelSeparator, $modelHash->separator);
+        $this->assertEquals($hashId, $model->hashId);
+        $this->assertEquals($model::class, $modelHash->modelClassName);
+    }
+
+    // endregion
+
     // region prefix_length
 
     /** @test */


### PR DESCRIPTION
Re-submitting this PR after some clean-up so that you don't have to sift through superfluous commits.

This is a pretty simple PR to support custom prefixes on a per-model basis, and when none is set the default logic takes precedence. I needed this functionality and saw it was on your project board, so thought I'd give it a go.

Please let me know if you'd like anything implemented in a different way!