### PR TITLE
Fix Route Model Binding

### DIFF
--- a/src/Support/Generator.php
+++ b/src/Support/Generator.php
@@ -65,7 +65,7 @@ class Generator
      *
      * @throws \Deligoez\LaravelModelHashId\Exceptions\UnknownHashIdConfigParameterException
      */
-    public static function parseHashIDForModel(string $hashId): ?HashIdDTO
+    public static function parseHashIDForModel(string $hashId, ?string $className = null): ?HashIdDTO
     {
         $generators = Config::get(ConfigParameters::MODEL_GENERATORS);
 
@@ -89,6 +89,10 @@ class Generator
         $genericLength = (int) Config::get(ConfigParameters::LENGTH);
         $genericSeparator = Config::get(ConfigParameters::SEPARATOR);
         $genericPrefixLength = Config::get(ConfigParameters::PREFIX_LENGTH);
+
+        if ($genericPrefixLength === -1) {
+            $genericPrefixLength = mb_strlen(self::buildPrefixForModel($className));
+        }
 
         if ($genericLength + $genericPrefixLength + mb_strlen($genericSeparator) === mb_strlen($hashId)) {
             return new HashIdDTO(

--- a/src/Traits/HasHashId.php
+++ b/src/Traits/HasHashId.php
@@ -66,7 +66,7 @@ trait HasHashId
      */
     public static function keyFromHashId(string $hashId): ?int
     {
-        $hashIdInstance = Generator::parseHashIDForModel($hashId);
+        $hashIdInstance = Generator::parseHashIDForModel($hashId, __CLASS__);
 
         if ($hashIdInstance === null) {
             return null;

--- a/tests/Traits/HasHasIdRoutingTest.php
+++ b/tests/Traits/HasHasIdRoutingTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Deligoez\LaravelModelHashId\Tests\Traits;
 
+use Deligoez\LaravelModelHashId\Support\ConfigParameters;
 use Deligoez\LaravelModelHashId\Tests\Models\ModelA;
 use Deligoez\LaravelModelHashId\Tests\TestCase;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Routing\Middleware\SubstituteBindings;
+use Deligoez\LaravelModelHashId\Support\Config;
+
 use Illuminate\Support\Facades\Route;
 
 class HasHasIdRoutingTest extends TestCase
@@ -69,6 +72,33 @@ class HasHasIdRoutingTest extends TestCase
     }
 
     /** @test */
+    public function it_can_resolve_a_hashID_via_route_model_binding_using_negative_one_prefix_legth(): void
+    {
+        // 1️⃣ Arrange 🏗
+        Config::set(ConfigParameters::PREFIX_LENGTH, -1);
+
+        ModelA::factory()->count($this->faker->numberBetween(2, 5))->create();
+        $model = ModelA::factory()->create(['name' => 'model-that-should-bind']);
+        $hashId = $model->hashId;
+
+
+        Route::get('/model-a/{modelA}', function (ModelA $modelA) {
+            return $modelA->toJson();
+        })->middleware(SubstituteBindings::class);
+
+        // 2️⃣ Act 🏋🏻‍
+        $response = $this->getJson("/model-a/{$hashId}");
+
+        // 3️⃣ Assert ✅
+        $response
+            ->assertOk()
+            ->assertJsonFragment([
+                'id'   => $model->getKey(),
+                'name' => 'model-that-should-bind',
+            ]);
+    }
+
+    /** @test */
     public function it_throws_a_model_not_found_exception_while_routing_with_model_key(): void
     {
         // 1️⃣ Arrange 🏗
@@ -88,4 +118,5 @@ class HasHasIdRoutingTest extends TestCase
         // 2️⃣ Act 🏋🏻‍
         $this->getJson("/model-a/{$model->getKey()}");
     }
+
 }


### PR DESCRIPTION
This PR is a proof of concept, and hopefully a starting point to fix a bug in the route model binding when the `prefix_length` is set to `-1`. 

The first commit is a failing test that validates the bug. 