### PR TITLE
Create validation rule for Hash Id

### DIFF
--- a/src/Rules/HashIdExists.php
+++ b/src/Rules/HashIdExists.php
@@ -33,7 +33,7 @@ class HashIdExists extends Exists implements ValidationRule, ValidatorAwareRule
 
         $validator = ValidatorFacade::make(
             [$attribute => $id],
-            [$attribute => (string) $this]
+            [$attribute =>  $this->buildParentRule()]
         );
 
         if ($validator->fails()) {
@@ -46,6 +46,14 @@ class HashIdExists extends Exists implements ValidationRule, ValidatorAwareRule
         $this->validator = $validator;
 
         return $this;
+    }
+
+    protected function buildParentRule(): Exists
+    {
+        return tap(new parent($this->model, (new $this->model)->getKeyName()), function (Exists $parent) {
+            $parent->wheres = $this->wheres;
+            $parent->using = $this->using;
+        });
     }
 
     protected function fail(string $attribute, Closure $fail): void {

--- a/src/Rules/HashIdExists.php
+++ b/src/Rules/HashIdExists.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deligoez\LaravelModelHashId\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
+use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\Validator;
+
+class HashIdExists extends Exists implements ValidationRule, ValidatorAwareRule
+{
+    protected Validator $validator;
+
+    /**
+     * @param  class-string<Model>  $model
+     */
+    public function __construct(protected string $model)
+    {
+        parent::__construct($model, (new $model)->getKeyName());
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! method_exists($this->model, 'keyFromHashId') || ! $id = $this->model::keyFromHashId($value)) {
+            $this->fail($attribute,$fail);
+            return;
+        }
+
+        $validator = ValidatorFacade::make(
+            [$attribute => $id],
+            [$attribute => (string) $this]
+        );
+
+        if ($validator->fails()) {
+             $this->fail($attribute, $fail);
+        }
+    }
+
+    public function setValidator(Validator $validator): static
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    protected function fail(string $attribute, Closure $fail): void {
+        $key = "{$attribute}.hashIdExists";
+
+        if (isset($this->validator->customMessages[$key])) {
+            $fail($this->validator->customMessages[$key]);
+        } else {
+            $fail('validation.exists')->translate([
+                'attribute' => $this->validator->getDisplayableAttribute($attribute),
+            ]);
+        }
+    }
+}

--- a/src/Traits/HasHashId.php
+++ b/src/Traits/HasHashId.php
@@ -74,6 +74,6 @@ trait HasHashId
 
         $generator = Generator::build(__CLASS__);
 
-        return $generator->decode($hashIdInstance->hashIdForKey)[0];
+        return $generator->decode($hashIdInstance->hashIdForKey)[0] ?? null;
     }
 }

--- a/tests/Rules/HashIdExistsTest.php
+++ b/tests/Rules/HashIdExistsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Deligoez\LaravelModelHashId\Tests\Rules;
+
+use Deligoez\LaravelModelHashId\Rules\HashIdExists;
+use Deligoez\LaravelModelHashId\Tests\Models\ModelA;
+use Deligoez\LaravelModelHashId\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Validator;
+
+class HashIdExistsTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    /** @test */
+    public function it_can_properly_validate_existing_hashId(): void
+    {
+        // 1. Arrange 🏗
+        ModelA::factory()->count($this->faker->numberBetween(2, 5))->create();
+        $model = ModelA::factory()->create(['name' => 'model-that-should-validate']);
+        $hashId = $model->hashId;
+
+        $validator = Validator::make(
+            ['test_id' => $hashId],
+            ['test_id' => [new HashIdExists(ModelA::class)]],
+        );
+
+        // 2. Act 🏋🏻‍
+        $passed = $validator->passes();
+
+        // 3. Assert ✅
+        $this->assertTrue($passed);
+    }
+
+    /** @test */
+    public function it_can_properly_validate_missing_hashId(): void
+    {
+        // 1. Arrange 🏗
+        ModelA::factory()->count($this->faker->numberBetween(2, 5))->create();
+        $model = ModelA::factory()->create(['name' => 'model-that-should-validate']);
+        $hashId = $model->hashId;
+        $model->delete();
+
+        $validator = Validator::make(
+            ['test_id' => $hashId],
+            ['test_id' => [new HashIdExists(ModelA::class)]],
+        );
+
+        // 2. Act 🏋🏻‍
+        $passed = $validator->passes();
+
+        // 3. Assert ✅
+        $this->assertFalse($passed);
+    }
+
+    /** @test */
+    public function it_can_return_proper_validation_attribute(): void
+    {
+        // 1. Arrange 🏗
+        ModelA::factory()->count($this->faker->numberBetween(2, 5))->create();
+        $model = ModelA::factory()->create(['name' => 'model-that-should-validate']);
+        $hashId = $model->hashId;
+        $model->delete();
+
+        $validator = Validator::make(
+            ['test_id' => $hashId],
+            ['test_id' => [new HashIdExists(ModelA::class)]],
+            [],
+            ['test_id' => 'TEST_ATTRIBUTE']
+        );
+
+        // 2. Act 🏋🏻‍
+        $passed = $validator->passes();
+        $messages = $validator->messages();
+
+        // 3. Assert ✅
+        $this->assertFalse($passed);
+        $this->assertStringContainsString('TEST_ATTRIBUTE', $messages->first('test_id'));
+    }
+
+    /** @test */
+    public function it_can_return_proper_validation_message(): void
+    {
+        // 1. Arrange 🏗
+        ModelA::factory()->count($this->faker->numberBetween(2, 5))->create();
+        $model = ModelA::factory()->create(['name' => 'model-that-should-validate']);
+        $hashId = $model->hashId;
+        $model->delete();
+
+        $validator = Validator::make(
+            ['test_id' => $hashId],
+            ['test_id' => [new HashIdExists(ModelA::class)]],
+            ['test_id.hashIdExists' => 'TEST_MESSAGE']
+        );
+
+        // 2. Act 🏋🏻‍
+        $passed = $validator->passes();
+        $messages = $validator->messages();
+
+        // 3. Assert ✅
+        $this->assertFalse($passed);
+        $this->assertContains('TEST_MESSAGE', $messages->get('test_id'));
+    }
+}


### PR DESCRIPTION
Hi.
I created this validation rule for my own purpose and I would like to contribute it to your package if it complies with your standards. I guess it's not the cleanest way to validate, but it works properly.

There is another commit I would like you to include (I guess even if you don't want this validation rule) that fixes an exception if you try to decode improper HashId. 
This is a valid hash for my salt: XvKGYlLgyARBM. If I change any character (eg. X**a**KGYlLgyARBM) `keyFromHashId` would thrown an Undefined array key exception.