### PR TITLE
Enable "new_with_parentheses" rule and update configurations

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -53,7 +53,6 @@
         ]
       ]
     },
-    "no_superfluous_phpdoc_tags": true,
     "no_superfluous_phpdoc_tags": {
       "allow_mixed": true
     },
@@ -85,6 +84,7 @@
         "property": "none",
         "trait_import": "none"
       }
-    }
+    },
+    "new_with_parentheses": true
   }
 }

--- a/src/LaravelModelHashIdServiceProvider.php
+++ b/src/LaravelModelHashIdServiceProvider.php
@@ -49,12 +49,12 @@ class LaravelModelHashIdServiceProvider extends ServiceProvider
      */
     protected function bootMixins(): void
     {
-        Builder::mixin(new FindByHashIdMixin);
-        Builder::mixin(new FindManyByHashIdMixin);
-        Builder::mixin(new FindOrFailByHashIdMixin);
-        Builder::mixin(new FindOrByHashIdMixin);
-        Builder::mixin(new FindOrNewByHashIdMixin);
-        Builder::mixin(new WhereHashIdMixin);
-        Builder::mixin(new WhereHashIdNotMixin);
+        Builder::mixin(new FindByHashIdMixin());
+        Builder::mixin(new FindManyByHashIdMixin());
+        Builder::mixin(new FindOrFailByHashIdMixin());
+        Builder::mixin(new FindOrByHashIdMixin());
+        Builder::mixin(new FindOrNewByHashIdMixin());
+        Builder::mixin(new WhereHashIdMixin());
+        Builder::mixin(new WhereHashIdNotMixin());
     }
 }

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -95,7 +95,7 @@ class Config
     public static function checkIfModelClassExist(Model|string $model): void
     {
         if (is_string($model) && !class_exists($model)) {
-            throw new ModelNotFoundException;
+            throw new ModelNotFoundException();
         }
     }
 }

--- a/tests/Mixins/FindOrByHashIdMixinTest.php
+++ b/tests/Mixins/FindOrByHashIdMixinTest.php
@@ -34,7 +34,7 @@ class FindOrByHashIdMixinTest extends TestCase
 
         // 2️⃣.2️⃣ Act 🏋🏻‍
         ModelA::findOrByHashId($model->hashId, function (): void {
-            throw new RuntimeException;
+            throw new RuntimeException();
         });
     }
 
@@ -59,7 +59,7 @@ class FindOrByHashIdMixinTest extends TestCase
 
         // 2️⃣.2️⃣ Act 🏋🏻‍
         ModelA::findOrByHashId($model->hashId, function (): void {
-            throw new RuntimeException;
+            throw new RuntimeException();
         });
     }
 }

--- a/tests/Support/HashIdModelConfigTest.php
+++ b/tests/Support/HashIdModelConfigTest.php
@@ -98,7 +98,7 @@ class HashIdModelConfigTest extends TestCase
         Config::set(ConfigParameters::SEPARATOR, $modelSpecificSeparator, ModelA::class);
 
         // 2. Act 🏋🏻‍
-        $modelSeparatorViaInstance  = Config::get(ConfigParameters::SEPARATOR, new ModelA);
+        $modelSeparatorViaInstance  = Config::get(ConfigParameters::SEPARATOR, new ModelA());
         $modelSeparatorViaClassName = Config::get(ConfigParameters::SEPARATOR, ModelA::class);
 
         // 3. Assert ✅

--- a/tests/Support/ModelHashIdGeneratorTest.php
+++ b/tests/Support/ModelHashIdGeneratorTest.php
@@ -25,7 +25,7 @@ class ModelHashIdGeneratorTest extends TestCase
     public function it_uses_default_prefix_logic_when_override_is_not_defined(): void
     {
         // 1. Arrange 🏗
-        $model        = new ModelA;
+        $model        = new ModelA();
         $prefixLength = $this->faker->numberBetween(1, mb_strlen(class_basename($model)));
         Config::set(ConfigParameters::PREFIX_LENGTH, $prefixLength, $model);
 
@@ -68,7 +68,7 @@ class ModelHashIdGeneratorTest extends TestCase
     public function it_can_set_prefix_length_for_a_model(): void
     {
         // 1. Arrange 🏗
-        $model        = new ModelA;
+        $model        = new ModelA();
         $prefixLength = $this->faker->numberBetween(1, mb_strlen(class_basename($model)));
         Config::set(ConfigParameters::PREFIX_LENGTH, $prefixLength, $model);
 
@@ -83,7 +83,7 @@ class ModelHashIdGeneratorTest extends TestCase
     public function prefix_length_will_be_the_length_of_class_name_if_prefix_length_is_under_zero(): void
     {
         // 1. Arrange 🏗
-        $model        = new ModelA;
+        $model        = new ModelA();
         $prefixLength = -1;
         Config::set(ConfigParameters::PREFIX_LENGTH, $prefixLength, $model);
 
@@ -113,7 +113,7 @@ class ModelHashIdGeneratorTest extends TestCase
     public function prefix_length_will_be_the_short_class_name_length_if_prefix_length_is_more_than_that(): void
     {
         // 1. Arrange 🏗
-        $model        = new ModelA;
+        $model        = new ModelA();
         $prefixLength = 10;
         Config::set(ConfigParameters::PREFIX_LENGTH, $prefixLength);
         $shortClassNameLength = mb_strlen(class_basename($model));
@@ -146,7 +146,7 @@ class ModelHashIdGeneratorTest extends TestCase
         Config::set(ConfigParameters::PREFIX_LENGTH, 6);
         Config::set(ConfigParameters::PREFIX_CASE, 'lower');
 
-        $model = new ModelA;
+        $model = new ModelA();
 
         // 2. Act 🏋🏻‍
         $prefix = Generator::buildPrefixForModel($model);
@@ -162,7 +162,7 @@ class ModelHashIdGeneratorTest extends TestCase
         Config::set(ConfigParameters::PREFIX_LENGTH, 6);
         Config::set(ConfigParameters::PREFIX_CASE, 'upper');
 
-        $model = new ModelA;
+        $model = new ModelA();
 
         // 2. Act 🏋🏻‍
         $prefix = Generator::buildPrefixForModel($model);
@@ -178,7 +178,7 @@ class ModelHashIdGeneratorTest extends TestCase
         Config::set(ConfigParameters::PREFIX_LENGTH, 6);
         Config::set(ConfigParameters::PREFIX_CASE, 'camel');
 
-        $model = new ModelA;
+        $model = new ModelA();
 
         // 2. Act 🏋🏻‍
         $prefix = Generator::buildPrefixForModel($model);
@@ -194,7 +194,7 @@ class ModelHashIdGeneratorTest extends TestCase
         Config::set(ConfigParameters::PREFIX_LENGTH, 6);
         Config::set(ConfigParameters::PREFIX_CASE, 'snake');
 
-        $model = new ModelA;
+        $model = new ModelA();
 
         // 2. Act 🏋🏻‍
         $prefix = Generator::buildPrefixForModel($model);
@@ -210,7 +210,7 @@ class ModelHashIdGeneratorTest extends TestCase
         Config::set(ConfigParameters::PREFIX_LENGTH, 6);
         Config::set(ConfigParameters::PREFIX_CASE, 'kebab');
 
-        $model = new ModelA;
+        $model = new ModelA();
 
         // 2. Act 🏋🏻‍
         $prefix = Generator::buildPrefixForModel($model);
@@ -226,7 +226,7 @@ class ModelHashIdGeneratorTest extends TestCase
         Config::set(ConfigParameters::PREFIX_LENGTH, 6);
         Config::set(ConfigParameters::PREFIX_CASE, 'title');
 
-        $model = new ModelA;
+        $model = new ModelA();
 
         // 2. Act 🏋🏻‍
         $prefix = Generator::buildPrefixForModel($model);
@@ -242,7 +242,7 @@ class ModelHashIdGeneratorTest extends TestCase
         Config::set(ConfigParameters::PREFIX_LENGTH, 6);
         Config::set(ConfigParameters::PREFIX_CASE, 'studly');
 
-        $model = new ModelA;
+        $model = new ModelA();
 
         // 2. Act 🏋🏻‍
         $prefix = Generator::buildPrefixForModel($model);
@@ -258,7 +258,7 @@ class ModelHashIdGeneratorTest extends TestCase
         Config::set(ConfigParameters::PREFIX_LENGTH, 6);
         Config::set(ConfigParameters::PREFIX_CASE, 'plural_studly');
 
-        $model = new ModelA;
+        $model = new ModelA();
 
         // 2. Act 🏋🏻‍
         $prefix = Generator::buildPrefixForModel($model);
@@ -364,7 +364,7 @@ class ModelHashIdGeneratorTest extends TestCase
     public function it_returns_null_if_model_does_not_have_a_key(): void
     {
         // 1. Arrange 🏗
-        $model = new ModelA;
+        $model = new ModelA();
 
         // 2. Act 🏋🏻‍
         $hashIdForModel = Generator::forModel($model);
@@ -377,7 +377,7 @@ class ModelHashIdGeneratorTest extends TestCase
     public function it_can_build_a_hash_id_generator_from_a_model_instance_or_class_name(): void
     {
         // 1. Arrange 🏗
-        $model = new ModelA;
+        $model = new ModelA();
 
         // 2. Act 🏋🏻‍
         $generatorFromInstance  = Generator::build($model);

--- a/tests/database/migrations/0000_00_00_000000_create_model_as_table.php
+++ b/tests/database/migrations/0000_00_00_000000_create_model_as_table.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-return new class extends Migration {
+return new class() extends Migration {
     public function up(): void
     {
         Schema::create('model_a_s', function (Blueprint $table): void {

--- a/tests/database/migrations/0000_00_00_000001_create_model_bs_table.php
+++ b/tests/database/migrations/0000_00_00_000001_create_model_bs_table.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-return new class extends Migration {
+return new class() extends Migration {
     public function up(): void
     {
         Schema::create('model_b_s', function (Blueprint $table): void {

--- a/tests/database/migrations/0000_00_00_000002_create_model_cs_table.php
+++ b/tests/database/migrations/0000_00_00_000002_create_model_cs_table.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-return new class extends Migration {
+return new class() extends Migration {
     public function up(): void
     {
         Schema::create('model_c_s', function (Blueprint $table): void {

--- a/tests/database/migrations/0000_00_00_000003_create_model_ds_table.php
+++ b/tests/database/migrations/0000_00_00_000003_create_model_ds_table.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-return new class extends Migration {
+return new class() extends Migration {
     public function up(): void
     {
         Schema::create('model_d_s', function (Blueprint $table): void {


### PR DESCRIPTION
Removed the boolean-only configuration for "no_superfluous_phpdoc_tags" to include an "allow_mixed" option. Added the "new_with_parentheses" rule to enforce consistency in object instantiation syntax.